### PR TITLE
snakemake rules & reprojecting to metres

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -89,3 +89,10 @@ roads:
     raw: roads_osm.osm
     processed: yem_tran_rds_ln_s1_osm_pp.shp
     url: https://overpass-api.de/api/interpreter?data=(area[\"ISO3166-1\"=\"YE\"][\"admin_level\"=\"2\"];)->.a;(way[highway](area.a););(._;>;);out qt;
+srtm:
+  srtm30:
+    dl_subdir: SRTM30tiles
+    processed: yem_elev_dem_ras_s1_srtm_pp_30m.tif
+  srtm90:
+    dl_subdir: SRTM90tiles
+    processed: yem_elev_dem_ras_s1_srtm_pp_90m.tif

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setuptools.setup(
             'extract_adm3_cod=extract.cod:get_adm3_snakemake',
             'extract_rivers_cod=extract.cod:get_rivers_snakemake',
             'extract_seaports_cod=extract.cod:get_seaports_snakemake',
+            'extract_srtm30=extract.strm:get_srtm30_snakemake',
+            'extract_srtm90=extract.strm:get_srtm90_snakemake',
             'extract_world_gadm=extract.gadm:get_world',
             'extract_geoboundaries=extract.geoboundaries:get_geoboundaries_adm',
             'extract_geoboundaries_adm0_all=extract.geoboundaries:get_all_adm0',

--- a/snakefile
+++ b/snakefile
@@ -103,6 +103,27 @@ rule extract_geoboundaries_adm0_all:
     shell:
         "extract_geoboundaries_adm0_all"
 
+# Extract SRTM
+rule extract_srtm30:
+    # not sure how to employ (optional) keyword arguments into snakemake
+    params:
+        os.path.join(config['dirs']['raw_data'], config['srtm']['srtm30']['dl_subdir'])
+        config['constants']['crs']
+    output:
+        os.path.join(config['dirs']['raw_data'], config['srtm']['srtm30']['processed_wgs84'])
+    shell:
+        "extract_srtm30 {params} {output}"
+
+rule extract_srtm90:
+    # not sure how to employ (optional) keyword arguments into snakemake
+    params:
+        os.path.join(config['dirs']['raw_data'], config['srtm']['srtm90']['dl_subdir'])
+        config['constants']['crs']
+    output:
+        os.path.join(config['dirs']['raw_data'], config['srtm']['srtm90']['processed_wgs84'])
+    shell:
+        "extract_srtm90 {params} {output}"
+
 ##TRANSFORM
 ##Transform HDX COD
 

--- a/snakefile
+++ b/snakefile
@@ -160,6 +160,7 @@ rule extract_geoboundaries_adm0_all:
         "extract_geoboundaries_adm0_all"
 
 # Extract SRTM
+# TODO Note: SRTM Snakemake rule does not currently work - functionality has been parked for SDS PoC
 rule extract_srtm30:
     # not sure how to employ (optional) keyword arguments into snakemake
     params:


### PR DESCRIPTION
Set up snakemake rules for srtm30 and srtm90 & reprojecting into local (metre) projection.

Unsure on 2 things:
1. How to implement optional keyword arguments into snakemake argument list and pipe into python
2. Where login credentials should live: at the moment, they are in src.extract.srtm.get_earthdata_login_credentials()
