### PR TITLE
Including name_local and par_pcode for all GADM admin levels.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,6 +6,7 @@ constants:
   ISO3: YEM
   ISO2: YE
   crs: EPSG:2090
+  crs_general: EPSG:4326
 adm0:
   schema: admin0_affected_area_py.yml
   # The GADM urls are all the same. The geopackage includes all available

--- a/schemas/gadm_admin_py.yml
+++ b/schemas/gadm_admin_py.yml
@@ -1,6 +1,8 @@
 required:
     - name_en
+    - name_local
     - pcode
+    - par_pcode
 properties:
     geometry_type:
         items:
@@ -11,5 +13,5 @@ properties:
     crs:
         items:
             enum:
-                - EPSG:2090
+                - EPSG:4326
         additionalItems: false


### PR DESCRIPTION
So GADM also has local names... I must have mistaken it for something else. Submitting minor changes as discussed yesterday to satisfy the schema as laid out in the Wiki Artefacts page for GADM admin boundaries.